### PR TITLE
feat: better status page

### DIFF
--- a/services/api/src/lib/download.ts
+++ b/services/api/src/lib/download.ts
@@ -96,7 +96,7 @@ export async function downloadAndInsertFile(
 
   const fileExists = forceDownload ? false : existsSync(resolve(holdingsIQDir, filename));
   if (!fileExists) {
-    addStep(portalName, '[holdingsIQ][download]', type);
+    addStep(`portal:${portalName}`, '[holdingsIQ][download]', type);
     try {
       id = await generateAndDownloadExport(
         portalConfig,
@@ -113,7 +113,7 @@ export async function downloadAndInsertFile(
     appLogger.info(`[${portalName}][${type}][holdingsIQ]: File [${filename}] already exists`);
   }
 
-  const insertStep = addStep(portalName, '[elastic][insert]', type);
+  const insertStep = addStep(`portal:${portalName}`, '[elastic][insert]', type);
   let lineUpserted;
   try {
     lineUpserted = await inserters[type](portalName, filename, index, date);
@@ -129,7 +129,7 @@ export async function downloadAndInsertFile(
     return;
   }
 
-  addStep(portalName, '[holdingsIQ][delete]', type);
+  addStep(`portal:${portalName}`, '[holdingsIQ][delete]', type);
   try {
     await deleteExportByID(portalConfig, id);
   } catch (err) {

--- a/services/api/src/lib/state.ts
+++ b/services/api/src/lib/state.ts
@@ -1,7 +1,7 @@
 import appLogger from '~/lib/logger/appLogger';
 
 type Step = Record<string, unknown> & {
-  portal: string;
+  key: string;
   name: string;
   fileType: string;
   startDate: Date;
@@ -44,9 +44,9 @@ export function fail() {
   state.status = 'error';
 }
 
-export function addStep(portal: string, name: string, fileType: string) {
+export function addStep(key: string, name: string, fileType: string) {
   const step: Step = {
-    portal,
+    key,
     name,
     fileType,
     startDate: new Date(),

--- a/services/api/src/lib/update.ts
+++ b/services/api/src/lib/update.ts
@@ -130,7 +130,7 @@ export default async function update(portal?: keyof Portals, forceDownload = fal
     }
 
     // #region Update OA
-    const accessTypeStep = addStep(portalName, '[elastic][insert][access_type]', 'KBART2');
+    const accessTypeStep = addStep(`portal:${portalName}`, '[elastic][insert][access_type]', 'KBART2');
     let lineUpserted;
     try {
       lineUpserted = await updateOA(portalName, index);
@@ -143,11 +143,13 @@ export default async function update(portal?: keyof Portals, forceDownload = fal
     // #endregion Update OA
   }
 
+  addStep('task:portals-update', '[elastic][insert][portals]', 'KBART2');
   try {
     await updatePortals(index);
   } catch (err) {
     appLogger.error(`[holdingsIQ]: Cannot update portals: ${err}`);
   }
+  endLatestStep();
 
   await redisClient.flushall();
 

--- a/services/frontend/components/administration/holdingsIQ/Card.vue
+++ b/services/frontend/components/administration/holdingsIQ/Card.vue
@@ -1,18 +1,25 @@
 <template>
-  <v-card>
-    <v-toolbar color="secondary" dark flat dense>
-      <v-toolbar-title>
-        {{ t('administration.holdingsIQ.title') }}
-      </v-toolbar-title>
+  <v-card :loading="loading && 'primary'">
+    <v-card-title class="d-flex align-center bg-secondary">
+      {{ t('administration.holdingsIQ.title') }}
       <v-spacer />
-      <AdministrationHoldingsIQReloadButton :loading="loading" @get-state="updateState()" />
-    </v-toolbar>
-    <v-card-actions class="d-flex justify-center">
-      <AdministrationHoldingsIQStartButton :status="status" />
-    </v-card-actions>
 
-    <v-card-text>
-      <AdministrationHoldingsIQState ref="stateRef" :status="status" />
+      <AdministrationHoldingsIQStartButton
+        :status="status"
+        class="mr-4"
+      />
+
+      <AdministrationHoldingsIQReloadButton
+        :loading="loading"
+        @get-state="updateState()"
+      />
+    </v-card-title>
+
+    <v-card-text class="mt-2">
+      <AdministrationHoldingsIQState
+        ref="stateRef"
+        :status="status"
+      />
     </v-card-text>
   </v-card>
 </template>

--- a/services/frontend/components/administration/holdingsIQ/ReloadButton.vue
+++ b/services/frontend/components/administration/holdingsIQ/ReloadButton.vue
@@ -1,31 +1,19 @@
 <template>
-  <v-tooltip location="bottom">
-    <template #activator="activator">
-      <v-btn
-        v-bind="activator.props"
-        icon="mdi-reload"
-        :disabled="props.loading"
-        @click.stop="getState()"
-      />
-    </template>
-    {{ t("report.reloadState") }}
-  </v-tooltip>
+  <v-btn
+    v-tooltip:bottom="$t('report.reloadState')"
+    :disabled="loading"
+    icon="mdi-reload"
+    variant="text"
+    @click.stop="$emit('getState')"
+  />
 </template>
 
 <script setup>
-
-const { t } = useI18n();
-
-const props = defineProps({
+defineProps({
   loading: { type: Boolean, default: false },
 });
 
-const emit = defineEmits({
+defineEmits({
   getState: () => true,
 });
-
-function getState() {
-  emit('getState');
-}
-
 </script>

--- a/services/frontend/components/administration/holdingsIQ/StartButton.vue
+++ b/services/frontend/components/administration/holdingsIQ/StartButton.vue
@@ -1,11 +1,15 @@
 <template>
-  <v-btn :loading="loading" :disabled="props.status" @click.stop="startUpdate()">
-    {{ t("update") }}
-  </v-btn>
+  <v-btn
+    :text="$t('update')"
+    :loading="loading"
+    :disabled="status"
+    prepend-icon="mdi-download-circle"
+    color="primary"
+    @click.stop="startUpdate()"
+  />
 </template>
 
 <script setup>
-
 const emit = defineEmits(['update']);
 
 const { t } = useI18n();
@@ -15,11 +19,11 @@ const { $fetch } = useNuxtApp();
 
 const { password } = storeToRefs(adminStore);
 
-const props = defineProps({
+defineProps({
   status: { type: Boolean, default: false },
 });
 
-const loading = ref(false);
+const loading = shallowRef(false);
 
 async function startUpdate() {
   loading.value = true;
@@ -42,5 +46,4 @@ async function startUpdate() {
 
   emit('update');
 }
-
 </script>

--- a/services/frontend/components/administration/holdingsIQ/State.vue
+++ b/services/frontend/components/administration/holdingsIQ/State.vue
@@ -1,53 +1,182 @@
 <template>
-  <div>
-    <v-row v-if="state.createdAt" class="justify-center ma-4">
-      Date: {{ state.createdAt }}
-    </v-row>
-    <v-row v-for="portal in portals" :key="portal.name" class="text-center">
-      <v-col>
-        <span> {{ portal }} </span>
+  <v-container fluid>
+    <v-row>
+      <v-col v-if="state.createdAt" cols="4">
+        <v-card
+          :title="state.createdAt"
+          :subtitle="$t('administration.holdingsIQ.createdAt')"
+          variant="flat"
+          density="compact"
+        >
+          <template #prepend>
+            <v-avatar
+              icon="mdi-clock"
+              class="bg-grey mr-2"
+              style="border-radius: 10%;"
+            />
+          </template>
+        </v-card>
+      </v-col>
 
-        <span v-if="stateGrouped[portal].every(step => step.status === 'done')" class="mx-2">
-          <v-icon color="green">
-            mdi-circle
-          </v-icon>
-        </span>
-
-        <span v-if="stateGrouped[portal].some(step => step.status === 'inProgress')" class="mx-2">
-          <v-progress-circular size="24" width="2" indeterminate color="blue" />
-          {{ stateGrouped[portal].filter(step => step.status === 'inProgress')[0].fileType }} -
-          {{ stateGrouped[portal].filter(step => step.status === 'inProgress')[0].name }}
-        </span>
-        <span v-if="stateGrouped[portal].some(step => step.status === 'error')" class="mx-2">
-          <v-icon color="red">
-            mdi-circle
-          </v-icon>
-          {{ stateGrouped[portal].filter(step => step.status === 'error')[0].fileType }} -
-          {{ stateGrouped[portal].filter(step => step.status === 'error')[0].name }}
-        </span>
+      <v-col v-else>
+        <v-alert
+          :title="$t('administration.holdingsIQ.noUpdate.title')"
+          :text="$t('administration.holdingsIQ.noUpdate.text')"
+          type="warning"
+        />
       </v-col>
     </v-row>
-  </div>
+
+    <v-row
+      v-for="group in stateGrouped"
+      :key="group.key"
+      :class="['border', 'border-opacity-50', `border-${STATUS_STYLES[group.status].color}`, 'rounded', 'mb-2']"
+    >
+      <v-col cols="3">
+        <v-card
+          :title="group.name"
+          :subtitle="$t(`administration.holdingsIQ.types.${group.type}`)"
+          variant="flat"
+          density="compact"
+        >
+          <template #prepend>
+            <v-avatar
+              :icon="TYPE_STYLES[group.type]?.icon || 'mdi-help'"
+              :class="[`bg-${TYPE_STYLES[group.type]?.color || 'grey'}`, 'mr-2']"
+              style="border-radius: 10%;"
+            />
+          </template>
+        </v-card>
+      </v-col>
+
+      <v-col cols="3">
+        <v-card
+          :title="$t(`administration.holdingsIQ.status.${group.status}`)"
+          :subtitle="$t('administration.holdingsIQ.status:title')"
+          variant="flat"
+          density="compact"
+        >
+          <template #prepend>
+            <v-avatar
+              :icon="STATUS_STYLES[group.status].icon"
+              :class="[`bg-${STATUS_STYLES[group.status].color}`, 'mr-2']"
+              style="border-radius: 10%;"
+            />
+          </template>
+        </v-card>
+      </v-col>
+
+      <v-col v-if="group.status === 'inProgress'" cols="3">
+        <v-card
+          :title="group.running.fileType"
+          :subtitle="group.running.name"
+          variant="flat"
+          density="compact"
+        >
+          <template #prepend>
+            <v-progress-circular
+              size="24"
+              width="2"
+              color="blue"
+              indeterminate
+              class="mr-6"
+            />
+          </template>
+        </v-card>
+      </v-col>
+
+      <v-col cols="3">
+        <v-card
+          v-if="group.status === 'error'"
+          :title="group.error.fileType"
+          :subtitle="group.error.name"
+          variant="flat"
+          density="compact"
+        >
+          <template #prepend>
+            <v-avatar
+              icon="mdi-alert-circle"
+              class="bg-error mr-2"
+              style="border-radius: 10%;"
+            />
+          </template>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script setup>
+const TYPE_STYLES = {
+  portal: {
+    color: 'primary',
+    icon: 'mdi-domain',
+  },
+  task: {
+    color: 'green',
+    icon: 'mdi-file-tree',
+  },
+};
 
-const { $fetch } = useNuxtApp();
+const STATUS_STYLES = {
+  done: {
+    color: 'success',
+    icon: 'mdi-check',
+  },
+  inProgress: {
+    color: 'blue',
+    icon: 'mdi-clock',
+  },
+  error: {
+    color: 'error',
+    icon: 'mdi-close',
+  },
+};
 
 const props = defineProps({
   status: { type: Boolean, default: false },
 });
 
-const loading = ref(false);
+const { $fetch } = useNuxtApp();
+const { t } = useI18n();
+
+const loading = shallowRef(false);
 const state = ref({});
 let intervalId = null;
 
 const stateGrouped = computed(() => {
-  const steps = state.value?.steps ?? [];
-  return Object.groupBy(steps, (item) => item.portal);
-});
+  const groups = Object.groupBy(state.value?.steps ?? [], (item) => item.key);
 
-const portals = computed(() => Object.keys(stateGrouped.value));
+  return Object.entries(groups).map(([key, steps]) => {
+    const [type, name] = key.split(':');
+
+    let label = '';
+    if (type === 'task') {
+      label = t(`administration.holdingsIQ.tasks.${name}`);
+    }
+
+    let status = 'done';
+
+    const inProgressSteps = steps.filter((step) => step.status === 'inProgress');
+    if (inProgressSteps.length > 0) {
+      status = 'inProgress';
+    }
+
+    const errorSteps = steps.filter((step) => step.status === 'error');
+    if (errorSteps.length > 0) {
+      status = 'error';
+    }
+
+    return {
+      key,
+      type,
+      name: label || name,
+      status,
+      running: inProgressSteps.at(0),
+      error: errorSteps.at(0),
+    };
+  });
+});
 
 async function getState() {
   loading.value = true;

--- a/services/frontend/locales/en.json
+++ b/services/frontend/locales/en.json
@@ -23,7 +23,25 @@
       "config": "Config"
     },
     "holdingsIQ": {
-      "title": "Update via Ebsco Holdings IQ API"
+      "title": "Update via Ebsco Holdings IQ API",
+      "noUpdate": {
+        "title": "No update were applied !",
+        "text": "Start one with the button \"Update\" located on the top right of this page."
+      },
+      "status:title": "Status",
+      "status": {
+        "done": "Done",
+        "inProgress": "In progress",
+        "error": "Error"
+      },
+      "types": {
+        "portal": "Portal",
+        "task": "Task"
+      },
+      "tasks": {
+        "portals-update": "Portals update"
+      },
+      "createdAt": "Started at"
     },
     "file": {
       "title": "List of installed files from unpaywall",
@@ -59,7 +77,7 @@
     "status": "Status"
   },
   "error": {
-    "administration" :{
+    "administration": {
       "invalidPassword": "Invalid password"
     },
     "file": {
@@ -69,13 +87,13 @@
     "report": {
       "get": "Cannot get update reports"
     },
-    "status":{
+    "status": {
       "get": "Cannot get update status"
     },
-    "state":{
+    "state": {
       "get": "Cannot get update state"
     },
-    "holdingsIQ" : {
+    "holdingsIQ": {
       "update": "Cannot start update"
     },
     "index": {
@@ -86,7 +104,7 @@
     "file": {
       "deleted": "File is deleted"
     },
-    "holdingsIQ" : {
+    "holdingsIQ": {
       "update": "The update has begun"
     }
   },

--- a/services/frontend/locales/fr.json
+++ b/services/frontend/locales/fr.json
@@ -23,7 +23,25 @@
       "config": "Config"
     },
     "holdingsIQ": {
-      "title": "Mise à jour via l'API Holdings IQ d'Ebsco"
+      "title": "Mise à jour via l'API Holdings IQ d'Ebsco",
+      "noUpdate": {
+        "title": "Aucune mise à jour n'a été effectuée !",
+        "text": "Lancez en une avec le bouton \"Mettre à jour\" situé en en haut à droite de cette page."
+      },
+      "status:title": "Status",
+      "status": {
+        "done": "Terminé",
+        "inProgress": "En cours",
+        "error": "Erreur"
+      },
+      "types": {
+        "portal": "Portail",
+        "task": "Tâche"
+      },
+      "tasks": {
+        "portals-update": "Mise à jour des portails"
+      },
+      "createdAt": "Démarré le"
     },
     "file": {
       "title": "Liste des fichiers installés de ReadHoldings",


### PR DESCRIPTION
# API

- [x] Steps can be used to track other things than `portals`
  - It uses a key formatted like `<type>:<name>`, ex: `portal:inc`

# Front

- [x] Uses the new steps
- [x] Refactored the whole page to enhance performances
- [x] Added message when no update are done yet

<img width="1639" height="223" alt="image" src="https://github.com/user-attachments/assets/7ba251ac-352c-4b89-b2b6-6b1909ca2fe2" />

<img width="1139" height="973" alt="image" src="https://github.com/user-attachments/assets/daca9f30-9eb2-4beb-b59e-c7726e2f6c9b" />
